### PR TITLE
Bluetooth: Mesh: Implement functions for the EMDS.

### DIFF
--- a/include/emds/emds.h
+++ b/include/emds/emds.h
@@ -84,12 +84,12 @@ int emds_init(void);
  * is called, takes the given data pointer and stores the data to the emergency
  * data storage.
  *
- * @param entry Entry to add to list.
+ * @param entry Entry to add to list and load data into.
  *
  * @retval 0 Success
  * @retval -ERRNO errno code if error
  */
-int emds_entry_add(struct emds_dynamic_entry *entry);
+int emds_entry_add(struct emds_entry *entry);
 
 /**
  * @brief Start the emergency data storage process.
@@ -107,12 +107,12 @@ int emds_entry_add(struct emds_dynamic_entry *entry);
 int emds_store(void);
 
 /**
- * @brief Load all data from the emergency data storage.
+ * @brief Load all static data from the emergency data storage.
  *
- * This function needs to be called after the static and dynamic entries are
- * added, as they are used to select the data to be loaded. The function also
- * needs to be called before the @ref emds_prepare function which will delete
- * all the stored data.
+ * This function needs to be called after the static entries are added, as they
+ * are used to select the data to be loaded. The function also needs to be
+ * called before the @ref emds_prepare function which will delete all the stored
+ * data.
  *
  * @retval 0 Success
  * @retval -ERRNO errno code if error
@@ -164,22 +164,18 @@ uint32_t emds_store_time_get(void);
 uint32_t emds_store_size_get(void);
 
 /**
- * @brief Check if the store operation has finished.
+ * @brief Check if the store operation can be run.
  *
- * @return Whether the store operation is still running or not.
+ * @return True if the store operation can be started, otherwise false.
  */
-bool emds_is_busy(void);
+bool emds_is_ready(void);
 
 /**
- * @brief Calculate the amount of space left in the flash area.
+ * @brief Check if the store operation has finished.
  *
- * The available flash area should always be larger than the size needed for the
- * registered data. If not, the flash needs to be cleared before the emergency
- * data is stored.
- *
- * @return Byte size for emergency space available in the flash storage.
+ * @return True if the store operation is completed, otherwise false.
  */
-uint32_t emds_store_size_available(void);
+bool emds_store_complete(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/emds/Kconfig
+++ b/subsys/emds/Kconfig
@@ -5,11 +5,13 @@
 #
 
 menuconfig EMDS
-	bool
-	prompt "Emergency Data Storage"
+	bool "Emergency Data Storage [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on PARTITION_MANAGER_ENABLED
+	depends on FLASH_MAP
 	default n
 	help
-	  Enable Emergency Data Storage.
+	  Enable Emergency Data Storage
 
 if EMDS
 
@@ -18,6 +20,41 @@ config EMDS_SECTOR_COUNT
 	default 1
 	help
 	  Number of sectors used for the emergency data storage area
+
+config EMDS_THREAD_STACK_SIZE
+	int "Stack size for the emergency data storage thread"
+	default 500
+	help
+	  Size of the stack that is initialized by the emergency data storage
+
+config EMDS_THREAD_PRIORITY
+	int "Priority for the emergency data storage thread"
+	default 0
+	help
+	  Cooperative priority for the emergency data storage thread. This will
+	  be used through K_PRIO_COOP(x), that means higher value gives lower
+	  priority.
+
+config EMDS_FLASH_TIME_WRITE_ONE_WORD_US
+	int "Time to write one word into flash"
+	default 41
+	help
+	  Max time to write one word (4 bytes) in flash (in microseconds)
+
+config EMDS_FLASH_TIME_ENTRY_OVERHEAD_US
+	int "Time to schedule write of one entry"
+	default 1410 if BT
+	default 42
+	help
+	   Max time to prepare the write of each entry (in microseconds)
+
+config EMDS_FLASH_TIME_BASE_OVERHEAD_US
+	int "Time to schedule the store process"
+	default 100000 if SETTINGS && !SOC_FLASH_NRF_PARTIAL_ERASE
+	default 5000 if SETTINGS && SOC_FLASH_NRF_PARTIAL_ERASE
+	default 500
+	help
+	   Max time to prepare the store process (in microseconds)
 
 module = EMDS
 module-str = emergency data storage

--- a/subsys/emds/emds.c
+++ b/subsys/emds/emds.c
@@ -6,55 +6,328 @@
 
 #include <emds/emds.h>
 
+#include <zephyr.h>
+#include <storage/flash_map.h>
+#include <drivers/flash.h>
+#include "emds_flash.h"
+
+#if defined(CONFIG_BT) && !defined(CONFIG_BT_LL_SW_SPLIT)
+#include <sdc.h>
+#include <mpsl.h>
+#endif
+
 #include <logging/log.h>
 LOG_MODULE_REGISTER(emds, CONFIG_EMDS_LOG_LEVEL);
 
+K_SEM_DEFINE(emds_sem, 0, 1);
+static bool emds_ready;
+static bool emds_initialized;
+static bool emds_complete;
+
+static sys_slist_t emds_dynamic_entries;
+static struct emds_fs emds_flash;
+
+static void emds_handler(void)
+{
+	k_sem_reset(&emds_sem);
+	k_sem_take(&emds_sem, K_FOREVER);
+
+	k_sched_lock();
+
+	LOG_DBG("Emergency Data Storeage released");
+
+	STRUCT_SECTION_FOREACH(emds_entry, ch) {
+		ssize_t len = emds_flash_write(&emds_flash,
+					ch->id, ch->data, ch->len);
+		if (len < 0) {
+			LOG_ERR("Write static entry: (%d) error (%d)",
+				ch->id, len);
+		} else if (len != ch->len) {
+			LOG_ERR("Write static entry: (%d) failed (%d:%d)",
+				ch->id, ch->len, len);
+		}
+	}
+
+	struct emds_dynamic_entry *ch;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		ssize_t len = emds_flash_write(&emds_flash,
+					ch->entry.id, ch->entry.data, ch->entry.len);
+		if (len < 0) {
+			LOG_ERR("Write dynamic entry: (%d) error (%d).",
+				ch->entry.id, len);
+		}
+		if (len != ch->entry.len) {
+			LOG_ERR("Write dynamic entry: (%d) failed (%d:%d).",
+				ch->entry.id, ch->entry.len, len);
+		}
+	}
+
+	emds_complete = true;
+	k_sched_unlock();
+}
+
+K_THREAD_DEFINE(emds_tid, CONFIG_EMDS_THREAD_STACK_SIZE, emds_handler, NULL,
+		NULL, NULL, K_PRIO_COOP(CONFIG_EMDS_THREAD_PRIORITY), 0, 0);
+
+static int emds_fs_init(void)
+{
+	int rc;
+	const struct flash_area *fa;
+	uint32_t sector_cnt = 1;
+	struct flash_sector hw_fs;
+	size_t emds_sector_size;
+	size_t emds_storage_size = 0;
+	uint16_t cnt = 0;
+
+	rc = flash_area_open(FLASH_AREA_ID(emds_storage), &fa);
+	if (rc) {
+		return rc;
+	}
+
+	rc = flash_area_get_sectors(FLASH_AREA_ID(emds_storage), &sector_cnt,
+						  &hw_fs);
+	if (rc == -ENODEV) {
+		return rc;
+	} else if (rc != 0 && rc != -ENOMEM) {
+		k_panic();
+	}
+
+	emds_sector_size = hw_fs.fs_size;
+
+	if (emds_sector_size > UINT16_MAX) {
+		return -EDOM;
+	}
+
+	while (cnt < CONFIG_EMDS_SECTOR_COUNT) {
+		emds_storage_size += emds_sector_size;
+		if (emds_storage_size > fa->fa_size) {
+			break;
+		}
+		cnt++;
+	}
+
+	emds_flash.sector_size = emds_sector_size;
+	emds_flash.sector_cnt = cnt;
+	emds_flash.offset = fa->fa_off;
+
+	return emds_flash_init(&emds_flash, fa->fa_dev_name);
+}
+
+
+static int emds_entries_size(uint32_t *size)
+{
+	size_t block_size = emds_flash.flash_params->write_block_size;
+	int entries = 0;
+
+	*size = 0;
+
+	STRUCT_SECTION_FOREACH(emds_entry, ch) {
+		*size += NRFX_CEIL_DIV(ch->len, block_size) * block_size;
+		*size += NRFX_CEIL_DIV(emds_flash.ate_size, block_size) * block_size;
+		entries++;
+	}
+
+	struct emds_dynamic_entry *ch;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		*size += NRFX_CEIL_DIV(ch->entry.len, block_size) * block_size;
+		*size += NRFX_CEIL_DIV(emds_flash.ate_size, block_size) * block_size;
+		entries++;
+	}
+
+	return entries;
+}
+
 int emds_init(void)
 {
+	int rc;
+
+	if (emds_initialized) {
+		LOG_DBG("Already initialized");
+		return -EALREADY;
+	}
+
+	rc = emds_fs_init();
+	if (rc) {
+		return rc;
+	}
+
+	sys_slist_init(&emds_dynamic_entries);
+
+	emds_initialized = true;
+
+	LOG_DBG("Emergency Data Storage initialized.");
+
 	return 0;
 }
 
-int emds_entry_add(struct emds_dynamic_entry *entry)
+int emds_entry_add(struct emds_entry *entry)
 {
+	struct emds_dynamic_entry *ch;
+	struct emds_dynamic_entry *item;
+
+	if (!emds_initialized) {
+		return -ECANCELED;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		if (ch->entry.id == entry->id) {
+			return -EINVAL;
+		}
+	}
+
+	item = k_malloc(sizeof(struct emds_dynamic_entry));
+	if (!item) {
+		return -ENOSPC;
+	}
+
+	item->entry = *entry;
+	sys_slist_append(&emds_dynamic_entries, &item->node);
+
 	return 0;
 }
 
 int emds_store(void)
 {
+	if (!emds_ready) {
+		return -ECANCELED;
+	}
+
+	/* Lock all interrupts */
+	(void)irq_lock();
+
+#if defined(CONFIG_BT) && !defined(CONFIG_BT_LL_SW_SPLIT)
+	/* Disable bluetooth and mpsl scheduler if bluetooth is enabled. */
+	int rc = sdc_disable(); // Replace with bt_disable when added.
+
+	if (rc) {
+		return rc;
+	}
+
+	mpsl_uninit();
+#endif
+	/* Start the emergency data storage process. */
+	k_sem_give(&emds_sem);
+
 	return 0;
 }
 
 int emds_load(void)
 {
+	struct emds_dynamic_entry *ch;
+
+	if (!emds_initialized) {
+		return -ECANCELED;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		ssize_t len = emds_flash_read(&emds_flash,
+					      ch->entry.id, ch->entry.data,
+					      ch->entry.len);
+
+		if (len < 0) {
+			if (len != -ENXIO) {
+				LOG_ERR("Read dynamic entry: (%d) error (%d)",
+					ch->entry.id, len);
+			}
+		} else if (len != ch->entry.len) {
+			LOG_WRN("Read dynamic entry: (%d) did not match (%d:%d).",
+				ch->entry.id, ch->entry.len, len);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(emds_entry, ch) {
+		ssize_t len = emds_flash_read(&emds_flash,
+					      ch->id, ch->data, ch->len);
+
+		if (len < 0) {
+			if (len != -ENXIO) {
+				LOG_ERR("Read static entry: (%d) error (%d)",
+					ch->id, len);
+			}
+		} else if (len != ch->len) {
+			LOG_WRN("Read static entry: (%d) entry did not match (%d:%d)",
+				ch->id, ch->len, len);
+		}
+	}
+
 	return 0;
 }
 
 int emds_clear(void)
 {
-	return 0;
+	if (!emds_initialized) {
+		return -ECANCELED;
+	}
+
+	return emds_flash_clear(&emds_flash);
 }
 
 int emds_prepare(void)
 {
+	int entries;
+	uint32_t size;
+	int rc;
+
+	if (!emds_initialized) {
+		return -ECANCELED;
+	}
+
+	entries = emds_entries_size(&size);
+
+	rc = emds_flash_prepare(&emds_flash, size);
+	if (rc) {
+		return rc;
+	}
+
+	emds_ready = true;
+
 	return 0;
 }
 
 uint32_t emds_store_time_get(void)
 {
-	return 0;
+	size_t block_size = emds_flash.flash_params->write_block_size;
+	uint32_t store_time_us = CONFIG_EMDS_FLASH_TIME_BASE_OVERHEAD_US;
+
+
+	STRUCT_SECTION_FOREACH(emds_entry, ch) {
+		store_time_us += NRFX_CEIL_DIV(ch->len, block_size) *
+					CONFIG_EMDS_FLASH_TIME_WRITE_ONE_WORD_US
+			       + NRFX_CEIL_DIV(emds_flash.ate_size, block_size) *
+					CONFIG_EMDS_FLASH_TIME_WRITE_ONE_WORD_US
+			       + CONFIG_EMDS_FLASH_TIME_ENTRY_OVERHEAD_US;
+	}
+
+	struct emds_dynamic_entry *ch;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&emds_dynamic_entries, ch, node) {
+		store_time_us += NRFX_CEIL_DIV(ch->entry.len, block_size) *
+					CONFIG_EMDS_FLASH_TIME_WRITE_ONE_WORD_US
+			       + NRFX_CEIL_DIV(emds_flash.ate_size, block_size) *
+					CONFIG_EMDS_FLASH_TIME_WRITE_ONE_WORD_US
+			       + CONFIG_EMDS_FLASH_TIME_ENTRY_OVERHEAD_US;
+	}
+
+	return store_time_us;
 }
 
 uint32_t emds_store_size_get(void)
 {
-	return 0;
+	uint32_t store_size;
+
+	(void)emds_entries_size(&store_size);
+
+	return store_size;
 }
 
-bool emds_is_busy(void)
+bool emds_is_ready(void)
 {
-	return false;
+	return emds_ready;
 }
 
-uint32_t emds_store_size_available(void)
+bool emds_store_complete(void)
 {
-	return 0;
+	return emds_complete;
 }

--- a/subsys/emds/emds_flash.c
+++ b/subsys/emds/emds_flash.c
@@ -400,15 +400,14 @@ ssize_t emds_flash_read(struct emds_fs *fs, uint16_t id, void *data, size_t len)
 	return wlk_ate.len;
 }
 
-int emds_flash_prepare(struct emds_fs *fs, int entry_cnt, int byte_size)
+int emds_flash_prepare(struct emds_fs *fs, int byte_size)
 {
 	if (!fs->is_initialized) {
 		LOG_ERR("EMDS flash not initialized");
 		return -EACCES;
 	}
 
-	if ((entry_cnt * fs->ate_size + byte_size) >
-	    (fs->sector_cnt * fs->sector_size) - fs->ate_size) {
+	if (byte_size > (fs->sector_cnt * fs->sector_size) - fs->ate_size) {
 		return -ENOMEM;
 	}
 
@@ -418,8 +417,7 @@ int emds_flash_prepare(struct emds_fs *fs, int entry_cnt, int byte_size)
 		return rc;
 	}
 
-	if (fs->force_erase ||
-	    ((entry_cnt * fs->ate_size + byte_size) > emds_flash_free_space_get(fs))) {
+	if (fs->force_erase || (byte_size > emds_flash_free_space_get(fs))) {
 		emds_flash_clear(fs);
 		fs->force_erase = false;
 	}

--- a/subsys/emds/emds_flash.h
+++ b/subsys/emds/emds_flash.h
@@ -120,12 +120,11 @@ ssize_t emds_flash_read(struct emds_fs *fs, uint16_t id, void *data, size_t len)
  * @warning Should only be called once.
  *
  * @param fs Pointer to file system
- * @param entry_cnt Total number of entries
- * @param byte_size Total number of data bytes
+ * @param byte_size Total number of bytes
  *
  * @retval 0 on success or negative error code
  */
-int emds_flash_prepare(struct emds_fs *fs, int entry_cnt, int byte_size);
+int emds_flash_prepare(struct emds_fs *fs, int byte_size);
 
 /**
  * @brief Get remaining raw space on the flash device.


### PR DESCRIPTION
Add implementation for the Emergency Data Storage. This storage should
be have its own storage area that can be quickly stored to at when
necessary. This way we can store data that is changing a lot without
wearing out the flash, and have a predefined time for storing the data.
There should be possible to determine how mush time is needed to store
all data configured to be stored in this area.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>